### PR TITLE
Add support for configuring using a single DB url parameter

### DIFF
--- a/Config/Config.php
+++ b/Config/Config.php
@@ -1,0 +1,60 @@
+<?php
+namespace mvrhov\PhinxBundle\Config;
+
+use Phinx\Config\Config as PhinxConfig;
+
+class Config extends PhinxConfig {
+
+    public function __construct(array $configArray, $configFilePath = null)
+    {
+        if (array_key_exists('environments', $configArray) && is_array($configArray['environments'])) {
+            $configArray['environments'] = $this->preprocessEnvironmentsConfiguration($configArray['environments']);
+        }
+
+        return parent::__construct($configArray, $configFilePath);
+    }
+
+    private function preprocessEnvironmentsConfiguration(array $environments)
+    {
+        foreach ($environments as $environment => $environmentData) {
+            if (!is_array($environmentData)) {
+                //This is some key like: ("default_database" => "default"),
+                //not an actual environment definition.
+                continue;
+            }
+
+            if (!array_key_exists('url', $environmentData)) {
+                //This environment likely contains (host, name, user, pass, port) like Phinx expects.
+                //No need to try and parse those out of a 'url' config value.
+                continue;
+            }
+
+            $matches = null;
+            if (!preg_match('/^([^:]+):\/\/([^:]+):([^@]+)@([^\/]+)\/(.+?)$/', $environmentData['url'], $matches)) {
+                throw new \Exception('Cannot parse database URI.');
+            }
+            list ($_fullMatch, $adapter, $dbUsername, $dbPassword, $dbHostAndPort, $dbName) = $matches;
+
+            $dbHost = $dbHostAndPort;
+            $dbPort = 3306;
+            if (preg_match('/^([^:]+):(\d+)$/', $dbHostAndPort, $dbHostMatches)) {
+                $dbHost = $dbHostMatches[1];
+                $dbPort = (int) $dbHostMatches[2];
+            }
+
+            unset($environmentData['url']);
+
+            $environmentData['adapter'] = $adapter;
+            $environmentData['name'] = $dbName;
+            $environmentData['host'] = $dbHost;
+            $environmentData['port'] = $dbPort;
+            $environmentData['user'] = $dbUsername;
+            $environmentData['pass'] = $dbPassword;
+
+            $environments[$environment] = $environmentData;
+        }
+
+        return $environments;
+    }
+
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -73,10 +73,17 @@ class Configuration implements ConfigurationInterface
                                         $v['pass'] = $v['password'];
                                         unset($v['password']);
                                     }
+
                                     return $v;
                                 })
                             ->end()
                             ->children()
+                                //Consumers can pass (adapter, name, host, port, user, pass)
+                                //in a single 'url' configuration parameter (convenient for Symfony >=4),
+                                //or they may pass them separately (convenient for Symfony<4).
+                                //
+                                //`mvrhov\PhinxBundle\Config\Config` takes care of normalizing the differences.
+                                ->scalarNode('url')->end()
                                 ->scalarNode('adapter')->end()
                                 ->scalarNode('name')->end()
                                 ->scalarNode('host')->defaultValue('localhost')->end()

--- a/DependencyInjection/mvrhovPhinxExtension.php
+++ b/DependencyInjection/mvrhovPhinxExtension.php
@@ -24,7 +24,7 @@
  */
 namespace mvrhov\PhinxBundle\DependencyInjection;
 
-use Phinx\Config\Config;
+use mvrhov\PhinxBundle\Config\Config;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;


### PR DESCRIPTION
Symfony 4 advises that a single DB url parameter be
defined (usually `DATABASE_URL`), instead of separating
all those values into multiple parameters.

To simplify this bundle's usage in Symfony 4,
the same url can now be provided as a `url` configuration
parameter. Because the Phinx library does not support `url`,
but rather wants it separated into (adapter, name, user, pass, etc.)
we're doing the parsing work by ourselves.

Eventually this code may get upstreamed to Phinx.

Fixes #8