### PR TITLE
Update phinx dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,6 @@
     },
     "require": {
         "php": ">=5.5",
-        "robmorgan/phinx": "^0.8|^0.9"
-    },
-    "minimum-stability": "dev",
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.9-dev"
-        }
+        "robmorgan/phinx": ">=0.8"
     }
 }


### PR DESCRIPTION
There is phinx `0.10.x` already, which has a [lot of nice features](https://github.com/cakephp/phinx/releases/tag/v0.10.0). It would be nice to use it and not being restricted to some phinx version.